### PR TITLE
Correction in CreateContainerCommand - Command with multiple args

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerbuildstep/cmd/CreateContainerCommand.java
@@ -110,7 +110,7 @@ public class CreateContainerCommand extends DockerCommand {
         DockerClient client = getClient(build, null);
         CreateContainerCmd cfgCmd = client.createContainerCmd(imageRes);
         if (!commandRes.isEmpty()) {
-            cfgCmd.withCmd(new String[] { commandRes });
+            cfgCmd.withCmd(commandRes.split(" "));
         }
         cfgCmd.withHostName(hostNameRes);
         cfgCmd.withName(containerNameRes);


### PR DESCRIPTION
Hi,
I couldn't create and start a container for Maven like specified in [the description of the official image](https://hub.docker.com/_/maven/).
I had this result :
```
[Docker] ERROR: command 'Start container(s)' failed: Cannot start container my-maven-project: [8] System error: exec: "mvn clean install": executable file not found in $PATH
```
I think the simplest way to correct it is to consider the command string like an array splited by spaces.

In a second time, it will be a good idea to consider syntax like ["mvn","clean","install"].

Regards,

BorX